### PR TITLE
feat: implements signup with email using firebase

### DIFF
--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -1,5 +1,20 @@
 import { initializeApp } from 'firebase/app';
-import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth';
+import {
+  getAuth,
+  signInWithPopup,
+  GoogleAuthProvider,
+  createUserWithEmailAndPassword,
+} from 'firebase/auth';
+import {
+  addDoc,
+  collection,
+  getDoc,
+  getDocs,
+  getFirestore,
+  query,
+  where,
+} from 'firebase/firestore';
+import { useState } from 'react';
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
@@ -10,16 +25,17 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const auth = getAuth();
 const provider = new GoogleAuthProvider();
+const firestore = new getFirestore(app);
 
 // Google Login
-export function googleLogin() {
-  console.log(firebaseConfig);
+export async function googleLogin() {
   signInWithPopup(auth, provider)
     .then((result) => {
       const credential = GoogleAuthProvider.credentialFromResult(result);
       const token = credential.accessToken;
       const user = result.user;
-      console.log(user);
     })
     .catch(console.error);
 }
+
+export { firestore, auth };

--- a/src/hooks/useShowToast.js
+++ b/src/hooks/useShowToast.js
@@ -1,0 +1,22 @@
+import { useToast } from '@chakra-ui/react';
+import { useCallback } from 'react';
+
+const useShowToast = () => {
+  const toast = useToast();
+  const showToast = useCallback(
+    (title, description, status) => {
+      toast({
+        title: title,
+        description: description,
+        status: status,
+        duration: 3000,
+        isClosable: true,
+      });
+    },
+    [toast]
+  );
+
+  return showToast;
+};
+
+export default useShowToast;

--- a/src/hooks/useSignupWithEmail.js
+++ b/src/hooks/useSignupWithEmail.js
@@ -1,0 +1,46 @@
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { useState } from 'react';
+import { auth, firestore } from '../firebase/firebase';
+import { addDoc, collection } from 'firebase/firestore';
+import useShowToast from './useShowToast';
+
+export default function useSignupWithEmail() {
+  const showToast = useShowToast();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const signUpWithEmail = async ({ email, password, username }) => {
+    try {
+      setLoading(true);
+      const userCredential = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      const user = userCredential.user;
+      const userDoc = {
+        uid: user.uid,
+        email: user.email,
+        username: username,
+        bio: '',
+        profilePicURL: '',
+        followers: [],
+        following: [],
+        posts: [],
+        createdAt: Date.now(),
+      };
+      await addDoc(collection(firestore, 'users', user.uid), userDoc);
+      localStorage.setItem('user-info', JSON.stringify(userDoc));
+    } catch (err) {
+      console.error(err);
+      if (err.code === 'auth/email-already-in-use') {
+        setError('이미 사용 중인 이메일입니다.');
+        throw error;
+      } else {
+        setError('회원가입 실패, 잠시 후 시도해주세요');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+  return { signUpWithEmail, loading, error };
+}

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -1,0 +1,25 @@
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { firestore } from '../firebase/firebase';
+
+export const isValidPassword = (password) => {
+  const passwordRegex =
+    /^(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{6,16}$/;
+  return passwordRegex.test(password);
+};
+
+export const checkUsernameExists = async (username) => {
+  try {
+    const q = query(
+      collection(firestore, 'users'),
+      where('username', '==', username)
+    );
+    const querySnapshot = await getDocs(q);
+    console.log('checkUsernameExists');
+    console.log('querySnapshot', querySnapshot);
+
+    return !querySnapshot.empty;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};


### PR DESCRIPTION
https://beginner2junior.tistory.com/18

### 파이어베이스로 회원가입, firestore에 저장.
- 비밀번호, 닉네임 중복검사 로직 validation.js에 작성
- useSignupEmail에서 return signup, error, loading
- error는 Signup에서 toast로 보여줌
- loading일때 회원가입 버튼 비활성화