### PR TITLE
feat: implements login, logout, sidebar, navbar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,20 @@
-import { Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import PageLayout from './layouts/PageLayout/PageLayout';
-
+import { useAuthStore } from './store/authStore.js';
 function App() {
+  const authUser = useAuthStore((state) => state.user);
+  const { pathname } = useLocation();
+
+  // 홈페이지 && 로그아웃 => 로그인 화면 이동
+  if (pathname === '/' && !authUser) {
+    return <Navigate to={'/auth'} />;
+  }
+
+  // 로그인페이지 && 로그인 => 홈으로 이동
+  if (pathname === '/auth' && authUser) {
+    return <Navigate to={'/'} />;
+  }
+
   return (
     <PageLayout>
       <Outlet />

--- a/src/components/AuthForm/Login.jsx
+++ b/src/components/AuthForm/Login.jsx
@@ -1,12 +1,13 @@
 import { Button, Input } from '@chakra-ui/react';
 import { useRef, useState } from 'react';
 import { updateFormData } from '../../util/form';
+import useLogin from '../../hooks/useLogin';
 
 export default function Login() {
+  const { signIn, loading } = useLogin();
   const [formData, setFormData] = useState({
     email: '',
     password: '',
-    confirmPassword: '',
   });
 
   const onChangeInput = (e) => {
@@ -16,6 +17,11 @@ export default function Login() {
 
   const emailInputRef = useRef(null);
   const pwInputRef = useRef(null);
+
+  const handleLogin = () => {
+    signIn(formData);
+  };
+
   return (
     <>
       <Input
@@ -38,7 +44,14 @@ export default function Login() {
         size={'sm'}
         ref={pwInputRef}
       />
-      <Button w={'full'} colorScheme='blue' size={'sm'} fontSize={14}>
+      <Button
+        w={'full'}
+        colorScheme='blue'
+        size={'sm'}
+        fontSize={14}
+        onClick={handleLogin}
+        isLoading={loading}
+      >
         Log in
       </Button>
     </>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,0 +1,32 @@
+import { Button, Container, Flex, Image, Text } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+
+const Navbar = () => {
+  return (
+    <Container maxW={'container.lg'} my={4}>
+      <Flex
+        w={'full'}
+        justifyContent={{ base: 'center', sm: 'space-between' }}
+        alignItems={'center'}
+      >
+        <Text fontSize={'2xl'} fontWeight={'bold'}>
+          Outstagram
+        </Text>
+        <Flex gap={4}>
+          <Link to='/auth'>
+            <Button colorScheme={'blue'} size={'sm'}>
+              Login
+            </Button>
+          </Link>
+          <Link to='/auth'>
+            <Button variant={'outline'} size={'sm'}>
+              Signup
+            </Button>
+          </Link>
+        </Flex>
+      </Flex>
+    </Container>
+  );
+};
+
+export default Navbar;

--- a/src/components/Sidebar/CreatePost.jsx
+++ b/src/components/Sidebar/CreatePost.jsx
@@ -6,7 +6,7 @@ const CreatePost = () => {
   return (
     <Tooltip
       hasArrow
-      label={'Profile'}
+      label={'Create Post'}
       placement='right'
       ml={1}
       openDelay={500}

--- a/src/components/Sidebar/Home.jsx
+++ b/src/components/Sidebar/Home.jsx
@@ -6,7 +6,7 @@ const Home = () => {
   return (
     <Tooltip
       hasArrow
-      label={'Profile'}
+      label={'Home'}
       placement='right'
       ml={1}
       openDelay={500}

--- a/src/components/Sidebar/Notifications.jsx
+++ b/src/components/Sidebar/Notifications.jsx
@@ -6,7 +6,7 @@ const Notification = () => {
   return (
     <Tooltip
       hasArrow
-      label={'Profile'}
+      label={'Notification'}
       placement='right'
       ml={1}
       openDelay={500}

--- a/src/components/Sidebar/Search.jsx
+++ b/src/components/Sidebar/Search.jsx
@@ -6,7 +6,7 @@ const Search = () => {
   return (
     <Tooltip
       hasArrow
-      label={'Profile'}
+      label={'Search'}
       placement='right'
       ml={1}
       openDelay={500}

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,9 +1,15 @@
-import { Box, Flex, Link, Text } from '@chakra-ui/react';
+import { Box, Button, Flex, Link, Text, Tooltip } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
 import SidebarItems from './SidebarItems';
 import { IoLogoInstagram } from 'react-icons/io';
+import { BiLogOut } from 'react-icons/bi';
+import useLogout from '../../hooks/useLogout';
 
 export default function Sidebar() {
+  const { logout, isLoggingOut, error } = useLogout();
+  const handleLogout = () => {
+    logout();
+  };
   return (
     <Box
       height={'100vh'}
@@ -44,6 +50,37 @@ export default function Sidebar() {
         <Flex direction={'column'} gap={5} cursor={'pointer'}>
           <SidebarItems />
         </Flex>
+
+        <Tooltip
+          hasArrow
+          label={'Logout'}
+          placement='right'
+          ml={1}
+          openDelay={500}
+          display={{ base: 'block', md: 'none' }}
+        >
+          <Flex
+            onClick={handleLogout}
+            alignItems={'center'}
+            gap={4}
+            _hover={{ bg: 'whiteAlpha.400' }}
+            borderRadius={6}
+            p={2}
+            w={{ base: 10, md: 'full' }}
+            mt={'auto'}
+            justifyContent={{ base: 'center', md: 'flex-start' }}
+          >
+            <BiLogOut size={25} />
+            <Button
+              display={{ base: 'none', md: 'block' }}
+              variant={'ghost'}
+              _hover={{ bg: 'transparent' }}
+              isLoading={isLoggingOut}
+            >
+              Logout
+            </Button>
+          </Flex>
+        </Tooltip>
       </Flex>
     </Box>
   );

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -4,6 +4,7 @@ import SidebarItems from './SidebarItems';
 import { IoLogoInstagram } from 'react-icons/io';
 import { BiLogOut } from 'react-icons/bi';
 import useLogout from '../../hooks/useLogout';
+import { useAuthStore } from '../../store/authStore';
 
 export default function Sidebar() {
   const { logout, isLoggingOut, error } = useLogout();

--- a/src/components/SuggestedUsers/SuggestedHeader.jsx
+++ b/src/components/SuggestedUsers/SuggestedHeader.jsx
@@ -1,25 +1,39 @@
-import { Avatar, Flex, Link, Text } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Avatar, Button, Flex, Text } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+import useLogout from '../../hooks/useLogout';
+import { useAuthStore } from '../../store/authStore';
 export default function SuggestedHeader() {
+  const { logout, isLoggingOut } = useLogout();
+  const handleLogout = () => {
+    logout();
+  };
+  const authUser = useAuthStore((state) => state.user);
+
   return (
     <Flex justifyContent={'space-between'} alignItems={'center'} w={'full'}>
       <Flex alignItems={'center'} gap={2}>
-        <Avatar name='username' size={'md'} src='/auth.png' />
-        <Text fontSize={12} fontWeight={'bold'}>
-          jay
-        </Text>
+        <Link to={`${authUser.username}`}>
+          <Avatar size={'md'} src={authUser.profilePicURL} />
+        </Link>
+        <Link to={`${authUser.username}`}>
+          <Text fontSize={12} fontWeight={'bold'}>
+            {authUser.username}
+          </Text>
+        </Link>
       </Flex>
-      <Link
-        to={'/auth'}
-        as={RouterLink}
+      <Button
+        size={'xs'}
+        background={'transparent'}
+        _hover={{ background: 'transparent' }}
         fontSize={14}
         fontWeight={'medium'}
         color={'blue.400'}
+        onClick={handleLogout}
+        isLoading={isLoggingOut}
         cursor={'pointer'}
-        style={{ textDecoration: 'none' }}
       >
         Log out
-      </Link>
+      </Button>
     </Flex>
   );
 }

--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -1,0 +1,45 @@
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import useShowToast from './useShowToast';
+import { auth, firestore } from '../firebase/firebase';
+import { useState } from 'react';
+import { collection, doc, getDoc, getDocs } from 'firebase/firestore';
+import { useAuthStore } from '../store/authStore';
+
+function useLogin() {
+  const showToast = useShowToast();
+  const [loading, setLoading] = useState(false);
+  const loginUser = useAuthStore((state) => state.login);
+
+  const signIn = async ({ email, password }) => {
+    if (!email || !password) {
+      showToast('Error', '모든 항목을 입력해주세요', 'error');
+    }
+    try {
+      setLoading(true);
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      if (userCredential) {
+        const docSnap = await getDocs(
+          collection(firestore, 'users', 'userId', userCredential.user.uid)
+        );
+        docSnap.forEach((doc) => {
+          const userData = doc.data();
+          localStorage.setItem('user-info', JSON.stringify(userData));
+          loginUser(userData);
+        });
+      }
+    } catch (err) {
+      console.error(err);
+      showToast('Error', '로그인 실패, 잠시 후 시도해주세요.', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { signIn, loading };
+}
+
+export default useLogin;

--- a/src/hooks/useLogout.js
+++ b/src/hooks/useLogout.js
@@ -1,0 +1,23 @@
+import { signOut } from 'firebase/auth';
+import { auth } from '../firebase/firebase';
+import { useState } from 'react';
+
+const useLogout = () => {
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [error, setError] = useState(null);
+  const logout = async () => {
+    try {
+      setIsLoggingOut(true);
+      signOut(auth);
+    } catch (err) {
+      console.error(err);
+      setError('로그아웃 과정에서 에러 발생');
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  return { logout, isLoggingOut, error };
+};
+
+export default useLogout;

--- a/src/hooks/useLogout.js
+++ b/src/hooks/useLogout.js
@@ -1,14 +1,17 @@
 import { signOut } from 'firebase/auth';
 import { auth } from '../firebase/firebase';
 import { useState } from 'react';
+import { useAuthStore } from '../store/authStore';
 
 const useLogout = () => {
+  const userLogout = useAuthStore((state) => state.logout);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [error, setError] = useState(null);
   const logout = async () => {
     try {
       setIsLoggingOut(true);
       signOut(auth);
+      userLogout();
     } catch (err) {
       console.error(err);
       setError('로그아웃 과정에서 에러 발생');

--- a/src/hooks/useSignupWithEmail.js
+++ b/src/hooks/useSignupWithEmail.js
@@ -2,12 +2,13 @@ import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { useState } from 'react';
 import { auth, firestore } from '../firebase/firebase';
 import { addDoc, collection } from 'firebase/firestore';
-import useShowToast from './useShowToast';
+import { useAuthStore } from '../store/authStore';
 
 export default function useSignupWithEmail() {
-  const showToast = useShowToast();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const loginUser = useAuthStore((state) => state.login);
+
   const signUpWithEmail = async ({ email, password, username }) => {
     try {
       setLoading(true);
@@ -28,15 +29,17 @@ export default function useSignupWithEmail() {
         posts: [],
         createdAt: Date.now(),
       };
-      await addDoc(collection(firestore, 'users', user.uid), userDoc);
+
+      await addDoc(collection(firestore, 'users', 'userId', user.uid), userDoc);
+
       localStorage.setItem('user-info', JSON.stringify(userDoc));
+      loginUser(userDoc);
     } catch (err) {
       console.error(err);
       if (err.code === 'auth/email-already-in-use') {
         setError('이미 사용 중인 이메일입니다.');
-        throw error;
       } else {
-        setError('회원가입 실패, 잠시 후 시도해주세요');
+        setError('회원가입 실패, 잠시 후 시도해주세요.');
       }
     } finally {
       setLoading(false);

--- a/src/layouts/PageLayout/PageLayout.jsx
+++ b/src/layouts/PageLayout/PageLayout.jsx
@@ -1,19 +1,31 @@
 import { Box, Flex } from '@chakra-ui/react';
 import Sidebar from '../../components/Sidebar/Sidebar';
 import { useLocation } from 'react-router-dom';
+import { useAuthStore } from '../../store/authStore';
+import Navbar from '../../components/Navbar/Navbar';
 
 export default function PageLayout({ children }) {
-  const { pathname } = useLocation();
+  const pathname = useLocation();
+  const user = useAuthStore((state) => state.user);
+  const renderSidebar = pathname !== '/auth' && user;
+  const renderNavbar = pathname !== '/auth' && !user;
+
   return (
-    <Flex>
+    <Flex flexDir={renderNavbar ? 'column' : 'row'}>
       {/* 왼쪽: 사이드바 */}
-      {pathname === '/auth' ? null : (
+      {renderSidebar ? (
         <Box w={{ base: '70px', md: '240px' }}>
           <Sidebar />
         </Box>
-      )}
+      ) : null}
+      {/* Nav */}
+      {renderNavbar ? <Navbar /> : null}
       {/* 오른쪽: 콘텐츠 */}
-      <Box flex={1} w={{ base: 'calc(100% - 70px)', md: 'calc(100%-240px)' }}>
+      <Box
+        flex={1}
+        w={{ base: 'calc(100% - 70px)', md: 'calc(100%-240px)' }}
+        mx={'auto'}
+      >
         {children}
       </Box>
     </Flex>

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -1,13 +1,13 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
-const authStore = create((set) => ({
+const store = (set) => ({
   user: null,
   login: (user) => set({ user }),
   logout: () => set({ user: null }),
   setUser: (user) => set({ user }),
-}));
+});
 
 export const useAuthStore = create(
-  persist(devtools(authStore), { name: 'authStore' })
+  persist(devtools(store), { name: 'authStore' })
 );


### PR DESCRIPTION
### 로그인, 로그아웃 구현
- 로그인은 회원가입에 비해 로직이 간단해서 input값 체크, 에러 메시지 띄우는 것을 useLogin에서 시행
- 처음 addDoc할때 collection으로 저장해서 getDocs도 collection으로 가져와야 했음
- 값 1개만 가져오기 위해 collection 저장, 가져올때 (firestore, 'users') -> collection(firestore, 'users', 'userId', userCredential.user.uid)로 id값 추가하는것으로 변경

### 사이드바, 네브바, 프로텍티드 라우팅
- 홈페이지 && 로그인 x -> '/auth'로 이동
- 로그인했는데 '/auth'에 있을경우 홈페이지로 이동
- sidebar는 로그인 && auth페이지가 아닐경우 에만 보여주고
- navbar는 로그인x, auth페이지 아닐 경우에만 보여주도록 PageLayout.jsx 수정  