### PR TITLE
feat: Implements update profile

### DIFF
--- a/src/components/Profile/EditProfile.jsx
+++ b/src/components/Profile/EditProfile.jsx
@@ -1,0 +1,176 @@
+import {
+  Avatar,
+  Button,
+  Center,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Heading,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+} from '@chakra-ui/react';
+import { useRef, useState } from 'react';
+import { useAuthStore } from '../../store/authStore';
+import usePreviewImg from '../../hooks/usePreviewImg';
+import useEditProfile from '../../hooks/useEditProfile';
+import useShowToast from '../../hooks/useShowToast';
+import { updateFormData } from '../../util/form';
+import { checkUsernameExists } from '../../util/validation';
+
+const EditProfile = ({ isOpen, onClose }) => {
+  const showToast = useShowToast();
+  const { user } = useAuthStore();
+  const [formdata, setFormData] = useState({
+    username: user.username,
+    bio: user.bio,
+  });
+  const [duplicatedUsername, setDuplicateUsername] = useState(false);
+
+  const { isUpdating, editProfile } = useEditProfile();
+  const fileRef = useRef(null);
+  const { handleImageChange, selectedFile, setSelectedFile } = usePreviewImg();
+
+  const onChangeInput = (e) => {
+    const { name, value } = e.target;
+    setFormData((prevFormData) => updateFormData(prevFormData, name, value));
+  };
+
+  const handleEditProfile = async () => {
+    try {
+      await editProfile(formdata, selectedFile);
+      setSelectedFile(null);
+      onClose();
+    } catch (error) {
+      showToast('Error', error.message, 'error');
+    }
+  };
+
+  const handleCheckUsername = async () => {
+    // 이미 존재하는 닉네임 && 기존 닉네임 아닐시 경고
+
+    const isExistsUsername = await checkUsernameExists(formdata.username);
+    if (isExistsUsername && formdata.username !== user.username) {
+      setDuplicateUsername(true);
+    } else {
+      setDuplicateUsername(false);
+    }
+  };
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent
+          bg={'black'}
+          boxShadow={'xl'}
+          border={'1px solid gray'}
+          mx={3}
+        >
+          <ModalHeader />
+          <ModalCloseButton />
+          <ModalBody>
+            <Flex bg={'black'}>
+              <Stack
+                spacing={4}
+                w={'full'}
+                maxW={'md'}
+                bg={'black'}
+                p={6}
+                my={0}
+              >
+                <Heading lineHeight={1.1} fontSize={{ base: '2xl', sm: '3xl' }}>
+                  Edit Profile
+                </Heading>
+                <FormControl>
+                  <Stack direction={['column', 'row']} spacing={6}>
+                    <Center>
+                      <Avatar
+                        size='xl'
+                        src={selectedFile || user.profilePicURL}
+                        border={'2px solid white '}
+                      />
+                    </Center>
+                    <Center w='full'>
+                      <Button w='full' onClick={() => fileRef.current.click()}>
+                        Edit Profile Picture
+                      </Button>
+                    </Center>
+                    <Input
+                      type='file'
+                      hidden
+                      ref={fileRef}
+                      onChange={handleImageChange}
+                    />
+                  </Stack>
+                </FormControl>
+
+                <FormControl isInvalid={duplicatedUsername}>
+                  <FormLabel fontSize={'sm'}>Username</FormLabel>
+                  <Input
+                    placeholder={'Username'}
+                    size={'sm'}
+                    type={'text'}
+                    name='username'
+                    value={formdata.username}
+                    onChange={onChangeInput}
+                    onBlur={handleCheckUsername}
+                  />
+                  {duplicatedUsername && (
+                    <FormErrorMessage textColor={'red'}>
+                      {`사용중인 닉네임입니다. 다시 입력하세요.`}
+                    </FormErrorMessage>
+                  )}
+                </FormControl>
+
+                <FormControl>
+                  <FormLabel fontSize={'sm'}>Bio</FormLabel>
+                  <Input
+                    placeholder={'Bio'}
+                    size={'sm'}
+                    type={'text'}
+                    name='bio'
+                    value={formdata.bio}
+                    onChange={onChangeInput}
+                  />
+                </FormControl>
+
+                <Stack spacing={6} direction={['column', 'row']}>
+                  <Button
+                    bg={'red.400'}
+                    color={'white'}
+                    w='full'
+                    size='sm'
+                    _hover={{ bg: 'red.500' }}
+                    onClick={onClose}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    bg={'blue.400'}
+                    color={'white'}
+                    size='sm'
+                    w='full'
+                    _hover={{ bg: 'blue.500' }}
+                    onClick={handleEditProfile}
+                    isLoading={isUpdating}
+                  >
+                    Submit
+                  </Button>
+                </Stack>
+              </Stack>
+            </Flex>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default EditProfile;

--- a/src/components/Profile/ProfileHeader.jsx
+++ b/src/components/Profile/ProfileHeader.jsx
@@ -5,9 +5,18 @@ import {
   Flex,
   Text,
   VStack,
+  useDisclosure,
 } from '@chakra-ui/react';
+import { useUserProfileStore } from '../../store/userProfileStore';
+import { useAuthStore } from '../../store/authStore';
+import EditProfile from './EditProfile';
 
 export default function ProfileHeader() {
+  const { userProfile } = useUserProfileStore();
+  const { user } = useAuthStore();
+  const ownProfile = user && user.username === userProfile.username;
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   return (
     <Flex
       gap={{ base: 4, sm: 10 }}
@@ -20,7 +29,7 @@ export default function ProfileHeader() {
         alignSelf={'flex-start'}
         mx={'auto'}
       >
-        <Avatar src={'/auth.png'} alt='' />
+        <Avatar src={userProfile.profilePicURL} alt='' />
       </AvatarGroup>
       <VStack alignItems={'start'} gap={2} mx={'auto'} flex={1}>
         <Flex
@@ -30,45 +39,64 @@ export default function ProfileHeader() {
           alignItems={'center'}
           w={'full'}
         >
-          <Text fontSize={{ base: 'sm', md: 'lg' }}>유저이름</Text>
-          <Flex gap={4} alignItems={'center'} justifyContent={'center'}>
-            <Button
-              bg={'white'}
-              color={'black'}
-              _hover={{ bg: 'whiteAlpha.800' }}
-              size={{ base: 'xs', md: 'sm' }}
-            >
-              Edit Profile
-            </Button>
-          </Flex>
+          <Text fontSize={{ base: 'sm', md: 'lg' }}>
+            {userProfile.username}
+          </Text>
+
+          {/* 로그인안할경우 null, 본인 프로필이면 수정버튼, 다른유저 프로필이면 follow/unfollow버튼 */}
+          {!user ? null : ownProfile ? (
+            <Flex gap={4} alignItems={'center'} justifyContent={'center'}>
+              <Button
+                bg={'white'}
+                color={'black'}
+                _hover={{ bg: 'whiteAlpha.800' }}
+                size={{ base: 'xs', md: 'sm' }}
+                onClick={onOpen}
+              >
+                Edit Profile
+              </Button>
+            </Flex>
+          ) : (
+            <Flex gap={4} alignItems={'center'} justifyContent={'center'}>
+              <Button
+                bg={'blue.500'}
+                color={'black'}
+                _hover={{ bg: 'whiteAlpha.800' }}
+                size={{ base: 'xs', md: 'sm' }}
+              >
+                Follow
+              </Button>
+            </Flex>
+          )}
         </Flex>
         <Flex alignItems={'center'} gap={{ base: 2, sm: 4 }}>
           <Text fontSize={{ base: 'xs', md: 'sm' }}>
             <Text as='span' fontWeight={'bold'} mr={1}>
-              12
+              {userProfile.posts.length}
             </Text>
             Posts
           </Text>
           <Text fontSize={{ base: 'xs', md: 'sm' }}>
             <Text as='span' fontWeight={'bold'} mr={1}>
-              123
+              {userProfile.followers.length}
             </Text>
             Followers
           </Text>
           <Text fontSize={{ base: 'xs', md: 'sm' }}>
             <Text as='span' fontWeight={'bold'} mr={1}>
-              123
+              {userProfile.following.length}
             </Text>
             Following
           </Text>
         </Flex>
         <Flex alignItems={'center'} gap={4}>
           <Text fontSize={'sm'} fontWeight={'bold'}>
-            Jay
+            {userProfile.username}
           </Text>
         </Flex>
-        <Text fontSize={'sm'}>커피를 좋아해요</Text>
+        <Text fontSize={'sm'}>{userProfile.bio}</Text>
       </VStack>
+      {isOpen && <EditProfile isOpen={isOpen} onClose={onClose} />}
     </Flex>
   );
 }

--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -1,41 +1,24 @@
 import { initializeApp } from 'firebase/app';
-import {
-  getAuth,
-  signInWithPopup,
-  GoogleAuthProvider,
-  createUserWithEmailAndPassword,
-} from 'firebase/auth';
-import {
-  addDoc,
-  collection,
-  getDoc,
-  getDocs,
-  getFirestore,
-  query,
-  where,
-} from 'firebase/firestore';
-import { useState } from 'react';
+import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
   databaseURL: import.meta.env.VITE_FIREBASE_DB_URL,
   projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
 };
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth();
 const provider = new GoogleAuthProvider();
 const firestore = new getFirestore(app);
+const storage = getStorage(app);
 
 // Google Login
 export async function googleLogin() {
-  signInWithPopup(auth, provider)
-    .then((result) => {
-      const credential = GoogleAuthProvider.credentialFromResult(result);
-      const token = credential.accessToken;
-      const user = result.user;
-    })
-    .catch(console.error);
+  signInWithPopup(auth, provider).catch(console.error);
 }
 
-export { firestore, auth, provider };
+export { firestore, auth, provider, storage };

--- a/src/hooks/useEditProfile.js
+++ b/src/hooks/useEditProfile.js
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { useAuthStore } from '../store/authStore';
+import { useUserProfileStore } from '../store/userProfileStore';
+import useShowToast from './useShowToast';
+import { getDownloadURL, ref, uploadString } from 'firebase/storage';
+import { firestore, storage } from '../firebase/firebase';
+import { doc, updateDoc } from 'firebase/firestore';
+
+const useEditProfile = () => {
+  const showToast = useShowToast();
+  const [isUpdating, setIsUpdating] = useState(false);
+  const { user, setUser } = useAuthStore();
+  const { setUserProfile } = useUserProfileStore();
+
+  const editProfile = async (formdata, selectedFile) => {
+    if (isUpdating || !user) return;
+    setIsUpdating(true);
+
+    const storageRef = ref(storage, `profilePics/${user.uid}`);
+    const userDocRef = doc(firestore, 'users', user.uid);
+    let URL = '';
+
+    try {
+      if (selectedFile) {
+        await uploadString(storageRef, selectedFile, 'data_url');
+        URL = await getDownloadURL(storageRef);
+      }
+
+      const updatedUser = {
+        ...user,
+        username: formdata.username || user.username,
+        bio: formdata.bio || user.bio,
+        profilePicURL: URL || user.profilePicURL,
+      };
+
+      await updateDoc(userDocRef, updatedUser);
+
+      localStorage.setItem('user-info', JSON.stringify(updatedUser));
+      setUser(updatedUser);
+      setUserProfile(updatedUser);
+      showToast(
+        'Success',
+        '프로필이 성공적으로 업데이트 되었습니다',
+        'success'
+      );
+    } catch (error) {
+      showToast(
+        'Error',
+        '프로필 업데이트 실패, 잠시 후 다시 시도해주세요',
+        'error'
+      );
+    }
+  };
+
+  return { editProfile, isUpdating };
+};
+
+export default useEditProfile;

--- a/src/hooks/useGetUserProfileByUsername.js
+++ b/src/hooks/useGetUserProfileByUsername.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import useShowToast from './useShowToast';
+import { firestore } from '../firebase/firebase';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { useUserProfileStore } from '../store/userProfileStore';
+
+function useGetUserProfileByUsername(username) {
+  const showToast = useShowToast();
+  const [isLoading, setIsLoading] = useState(true);
+  const { userProfile, setUserProfile } = useUserProfileStore();
+
+  useEffect(() => {
+    const getUserProfile = async () => {
+      setIsLoading(true);
+      try {
+        const q = query(
+          collection(firestore, 'users'),
+          where('username', '==', username)
+        );
+        const querySnapShot = await getDocs(q);
+
+        if (querySnapShot.empty) return setUserProfile(null);
+
+        let userDoc;
+        querySnapShot.forEach((doc) => {
+          userDoc = doc.data();
+        });
+
+        setUserProfile(userDoc);
+      } catch (error) {
+        showToast('Error', error.message, 'error');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    getUserProfile();
+  }, [setUserProfile, showToast, username]);
+
+  return { isLoading, userProfile };
+}
+
+export default useGetUserProfileByUsername;

--- a/src/hooks/usePreviewImg.js
+++ b/src/hooks/usePreviewImg.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import useShowToast from './useShowToast';
+
+const usePreviewImg = () => {
+  const [selectedFile, setSelectedFile] = useState(null);
+  const showToast = useShowToast();
+  const maxFileSizeInBytes = 2 * 1024 * 1024;
+
+  const handleImageChange = (e) => {
+    const file = e.target.files[0];
+    if (file && file.type.startsWith('image/')) {
+      if (file.size > maxFileSizeInBytes) {
+        showToast('Error', '2MB이하의 파일을 선택해주세요', 'error');
+        setSelectedFile(null);
+        return;
+      }
+      const reader = new FileReader();
+
+      reader.onloadend = () => {
+        setSelectedFile(reader.result);
+      };
+
+      reader.onerror = (error) => {
+        console.error('File읽는중 에러발생', error);
+        showToast('Error', '파일을 다시 선택해주세요', 'error');
+        setSelectedFile(null);
+      };
+
+      reader.readAsDataURL(file);
+    } else {
+      showToast('Error', '이미지 파일을 선택해주세요', 'error');
+      setSelectedFile(null);
+    }
+  };
+
+  return { selectedFile, handleImageChange, setSelectedFile };
+};
+
+export default usePreviewImg;

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -1,9 +1,26 @@
-import { Container, Flex } from '@chakra-ui/react';
+import {
+  Container,
+  Flex,
+  Link,
+  Skeleton,
+  SkeletonCircle,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
 import ProfileHeader from '../../components/Profile/ProfileHeader';
 import ProfileTabs from '../../components/Profile/ProfileTabs';
 import ProfilePosts from '../../components/Profile/ProfilePosts';
+import { useParams } from 'react-router-dom';
+import useGetUserProfileByUsername from '../../hooks/useGetUserProfileByUsername';
+import { Link as RouterLink } from 'react-router-dom';
 
-export default function ProfilePage() {
+const ProfilePage = () => {
+  const { username } = useParams();
+  const { isLoading, userProfile } = useGetUserProfileByUsername(username);
+
+  const userNotFound = !isLoading && !userProfile;
+  if (userNotFound) return <UserNotFound />;
+
   return (
     <Container maxW={'container.lg'} py={5}>
       <Flex
@@ -14,7 +31,8 @@ export default function ProfilePage() {
         mx={'auto'}
         flexDirection={'column'}
       >
-        <ProfileHeader />
+        {isLoading && <ProfileHeaderSkeleton />}
+        {!isLoading && userProfile && <ProfileHeader />}
       </Flex>
       <Flex
         px={{ base: 2, sm: 4 }}
@@ -29,4 +47,47 @@ export default function ProfilePage() {
       </Flex>
     </Container>
   );
-}
+};
+
+export default ProfilePage;
+
+const ProfileHeaderSkeleton = () => {
+  return (
+    <Flex
+      gap={{ base: 4, sm: 10 }}
+      py={10}
+      direction={{ base: 'column', sm: 'row' }}
+      justifyContent={'center'}
+      alignItems={'center'}
+    >
+      <SkeletonCircle size='24' />
+
+      <VStack
+        alignItems={{ base: 'center', sm: 'flex-start' }}
+        gap={2}
+        mx={'auto'}
+        flex={1}
+      >
+        <Skeleton height='12px' width='150px' />
+        <Skeleton height='12px' width='100px' />
+      </VStack>
+    </Flex>
+  );
+};
+
+const UserNotFound = () => {
+  return (
+    <Flex flexDir='column' textAlign={'center'} mx={'auto'}>
+      <Text fontSize={'2xl'}>User Not Found</Text>
+      <Link
+        as={RouterLink}
+        to={'/'}
+        color={'blue.500'}
+        w={'max-content'}
+        mx={'auto'}
+      >
+        홈페이지로 이동
+      </Link>
+    </Flex>
+  );
+};

--- a/src/store/userProfileStore.js
+++ b/src/store/userProfileStore.js
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+
+const store = (set) => ({
+  userProfile: null,
+  setUserProfile: (userProfile) => set({ userProfile }),
+  // addPost:
+});
+
+export const useUserProfileStore = create(
+  persist(devtools(store), { name: 'userProfileStore' })
+);


### PR DESCRIPTION
## 프로필 업데이트 기능 구현
- 프로필의 이미지, 자기소개, 유저네임 수정 기능 구현
- chakra-ui의 fomcontroller이용
- 이미지 업로드, 프리뷰 부분 -> usePreviewImg.js에서 fileReader이용해 setImage
- updatedUser객체 만들어서 firestore의 doc(firestore, 'users', user.uid)에 업데이트

### 수정한 부분
- 폼에서 username부분 onBlur로 닉네임 중복체크
- chakra-ui의 FormErrorMessage로 닉네임 변경 요청 메시지 띄움
-  초기값을 user값으로 지정
- 이미지 업로드 로직에 reader.onerror 파일읽기 오류 처리
