### PR TITLE
feat: ReactQuery적용, fetch분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@tanstack/react-query": "^5.35.5",
+        "@tanstack/react-query-devtools": "^5.35.5",
         "firebase": "^10.11.0",
         "framer-motion": "^11.1.7",
         "react": "^18.2.0",
@@ -5449,6 +5451,55 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.35.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.35.5.tgz",
+      "integrity": "sha512-OMWvlEqG01RfGj+XZb/piDzPp0eZkkHWSDHt2LvE/fd1zWburP/xwm0ghk6Iv8cuPlP+ACFkZviKXK0OVt6lhg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.32.1.tgz",
+      "integrity": "sha512-7Xq57Ctopiy/4atpb0uNY5VRuCqRS/1fi/WBCKKX6jHMa6cCgDuV/AQuiwRXcKARbq2OkVAOrW2v4xK9nTbcCA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.35.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.35.5.tgz",
+      "integrity": "sha512-sppX7L+PVn5GBV3In6zzj0zcKfnZRKhXbX1MfIfKo1OjIq2GMaopvAFOP0x1bRYTUk2ikrdYcQYOozX7PWkb8A==",
+      "dependencies": {
+        "@tanstack/query-core": "5.35.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.35.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.35.5.tgz",
+      "integrity": "sha512-4Xll14B9uhgEJ+uqZZ5tqZ7G1LDR7wGYgb+NOZHGn11TTABnlV8GWon7zDMqdaHeR5mjjuY1UFo9pbz39kuZKQ==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.32.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.35.5",
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@tanstack/react-query": "^5.35.5",
+    "@tanstack/react-query-devtools": "^5.35.5",
     "firebase": "^10.11.0",
     "framer-motion": "^11.1.7",
     "react": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ function App() {
     defaultOptions: {
       queries: {
         staleTime: 60 * 1000,
+        cacheTime: 10 * 60 * 1000,
       },
     },
   });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,18 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import PageLayout from './layouts/PageLayout/PageLayout';
 import { useAuthStore } from './store/authStore.js';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 function App() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+
   const authUser = useAuthStore((state) => state.user);
   const { pathname } = useLocation();
 
@@ -16,9 +27,12 @@ function App() {
   }
 
   return (
-    <PageLayout>
-      <Outlet />
-    </PageLayout>
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+      <PageLayout>
+        <Outlet />
+      </PageLayout>
+    </QueryClientProvider>
   );
 }
 

--- a/src/api/fetchFeedPosts.js
+++ b/src/api/fetchFeedPosts.js
@@ -1,0 +1,50 @@
+import {
+  collection,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  where,
+} from 'firebase/firestore';
+import { firestore } from '../firebase/firebase';
+const PAGE_SIZE = 1;
+
+const fetchFeedPosts = async ({ queryKey, pageParam }) => {
+  const user = queryKey[2];
+
+  if (user.following.length === 0) {
+    return [];
+  }
+
+  const q = query(
+    collection(firestore, 'posts'),
+    where('createdBy', 'in', user.following)
+  );
+
+  try {
+    let querySnapshot;
+
+    if (pageParam == 0) {
+      querySnapshot = await getDocs(
+        query(q, orderBy('createdAt'), limit(PAGE_SIZE))
+      );
+    } else {
+      querySnapshot = await getDocs(
+        query(q, startAfter(pageParam), orderBy('createdAt'), limit(PAGE_SIZE))
+      );
+    }
+
+    const feedPosts = [];
+    querySnapshot.forEach((doc) => {
+      feedPosts.push({ id: doc.id, ...doc.data() });
+    });
+
+    return feedPosts.sort((a, b) => b.createdAt - a.createdAt);
+  } catch (error) {
+    console.error('게시글 로딩 중 error', error);
+    throw error;
+  }
+};
+
+export default fetchFeedPosts;

--- a/src/components/FeedPosts/FeedPosts.jsx
+++ b/src/components/FeedPosts/FeedPosts.jsx
@@ -9,14 +9,30 @@ import {
 } from '@chakra-ui/react';
 import FeedPost from './FeedPost';
 import useGetFeedPosts from '../../hooks/useGetFeedPosts';
+import { useEffect, useState } from 'react';
 
 function FeedPosts() {
-  const { isLoading, posts } = useGetFeedPosts();
+  const {
+    data: posts,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useGetFeedPosts();
 
-  return (
-    <Container maxW={'container.sm'} py={10} px={2}>
-      {isLoading &&
-        [0, 1, 2].map((_, idx) => (
+  const [cnt, setCnt] = useState(1);
+
+  useEffect(() => {
+    if (!isLoading && !isFetchingNextPage && hasNextPage && cnt < 2) {
+      fetchNextPage();
+      setCnt((prev) => prev + 1);
+    }
+  }, [isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, cnt]);
+
+  if (isLoading) {
+    return (
+      <Container maxW={'container.sm'} py={10} px={2}>
+        {[0, 1, 2].map((_, idx) => (
           <VStack key={idx} gap={4} alignItems={'flex-start'} mb={10}>
             <Flex gap={2}>
               <SkeletonCircle size={10} />
@@ -30,17 +46,26 @@ function FeedPosts() {
             </Skeleton>
           </VStack>
         ))}
-      {!isLoading &&
-        posts.length > 0 &&
-        posts.map((post) => <FeedPost key={post.id} post={post} />)}
-      {!isLoading && posts.length === 0 && (
-        <>
+      </Container>
+    );
+  }
+  return (
+    posts?.pages && (
+      <Container maxW={'container.sm'} py={10} px={2}>
+        {posts?.pages.map((page, i) => (
+          <Box key={i}>
+            {page.map((post) => (
+              <FeedPost key={post.id} post={post} />
+            ))}
+          </Box>
+        ))}
+        {posts.pages.length === 0 && (
           <Text fontSize={'md'} color={'blue.400'}>
             다른 유저를 팔로우하고, 게시글을 확인해보세요 :D
           </Text>
-        </>
-      )}
-    </Container>
+        )}
+      </Container>
+    )
   );
 }
 

--- a/src/hooks/useGetFeedPosts.js
+++ b/src/hooks/useGetFeedPosts.js
@@ -1,56 +1,36 @@
-import { useEffect, useState } from 'react';
 import useShowToast from './useShowToast';
 import { useAuthStore } from '../store/authStore';
-import { usePostStore } from '../store/postStore';
-import { useUserProfileStore } from '../store/userProfileStore';
-import { collection, getDocs, query, where } from 'firebase/firestore';
-import { firestore } from '../firebase/firebase';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import fetchFeedPosts from '../api/fetchFeedPosts';
 
 const useGetFeedPosts = () => {
   const showToast = useShowToast();
-  const [isLoading, setIsLoading] = useState(false);
-  const { posts, setPosts } = usePostStore();
   const { user } = useAuthStore();
-  const { setUserProfile } = useUserProfileStore();
 
-  useEffect(() => {
-    const getFeedPosts = async () => {
-      setIsLoading(true);
-      if (user.following.length === 0) {
-        setIsLoading(false);
-        setPosts([]);
-        return;
-      }
-      const q = query(
-        collection(firestore, 'posts'),
-        where('createdBy', 'in', user.following)
-      );
-      try {
-        const querySnapshot = await getDocs(q);
-        const feedPosts = [];
-
-        querySnapshot.forEach((doc) => {
-          feedPosts.push({ id: doc.id, ...doc.data() });
-        });
-
-        feedPosts.sort((a, b) => b.createdAt - a.createdAt);
-        setPosts(feedPosts);
-      } catch (error) {
-        console.error(error);
+  const { fetchNextPage, hasNextPage, data, isLoading, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ['posts', 'main', user],
+      queryFn: fetchFeedPosts,
+      retry: false,
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => {
+        console.log('laspage', lastPage);
+        if (lastPage) {
+          console.log('laspage', lastPage[lastPage.length - 1]?.createdAt);
+          return lastPage[lastPage.length - 1]?.createdAt;
+        }
+        return null;
+      },
+      onError: () => {
         showToast(
           'Error',
           '게시글 로딩 중 오류 발생, 잠시 후 시도해주세요',
           'error'
         );
-      } finally {
-        setIsLoading(false);
-      }
-    };
+      },
+    });
 
-    if (user) getFeedPosts();
-  }, [user, showToast, setPosts, setUserProfile]);
-
-  return { isLoading, posts };
+  return { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage };
 };
 
 export default useGetFeedPosts;

--- a/src/hooks/useGetUserPosts.js
+++ b/src/hooks/useGetUserPosts.js
@@ -22,7 +22,6 @@ const useGetUserPosts = () => {
           collection(firestore, 'posts'),
           where('createdBy', '==', userProfile.uid)
         );
-
         const querySnapshot = await getDocs(q);
 
         const posts = [];


### PR DESCRIPTION
## ReactQuery적용, fetch분리
- FeedPosts의 data를 useGetFeedPost에서 가져오는 기존형식
- useGetFeedPost를 useInfiniteQuery사용하게 변경, data + fetchNextPage등의 함수도 return
- 네트워크 fetch (firebase에서 데이터 가져오는 과정) fetchPost.js로 분리
- fetchPost에서 createdAt순으로 정렬해서 lastPageParam부터 limit만큼 가져오기
- firebase console에 index추가
 
### 추가 진행 필요:
- infiniteScroll필요
- 추후 최신순, 오래된순, 기타 정렬 추가시 useGetFeedPost에 parameter로 넘겨서 queryKey로 전달. 일단은 최신순으로만 정렬