### PR TITLE
feat: added followList

### DIFF
--- a/src/api/User/apiFollow.js
+++ b/src/api/User/apiFollow.js
@@ -1,1 +1,0 @@
-export const toggleFollow = () => {};

--- a/src/components/Modals/FollowerModal.jsx
+++ b/src/components/Modals/FollowerModal.jsx
@@ -1,23 +1,16 @@
 import {
-  Avatar,
-  Button,
-  Divider,
   Flex,
-  Image,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalOverlay,
-  Spinner,
   Text,
   VStack,
 } from '@chakra-ui/react';
-import useGetSuggestedUsers from '../../hooks/User/useGetSuggestedUsers';
 import SuggestedUser from '../SuggestedUsers/SuggestedUser';
 
-const UserModal = ({ mode = '', isOpen, onClose }) => {
-  const { isLoading, suggestedUsers } = useGetSuggestedUsers();
+const FollowerModal = ({ users, isOpen, onClose }) => {
   return (
     <Modal
       isOpen={isOpen}
@@ -30,26 +23,20 @@ const UserModal = ({ mode = '', isOpen, onClose }) => {
         <ModalCloseButton />
         <ModalBody bg={'black'} pb={5}>
           <VStack py={8} px={6} gap={4}>
-            {suggestedUsers.length !== 0 && (
+            {users?.length !== 0 && (
               <Flex
                 justifyContent={'space-between'}
                 alignItems={'center'}
                 w={'full'}
               >
                 <Text fontSize={12} fontWeight={'bold'} color={'gray.500'}>
-                  {mode} userList
+                  follower List
                 </Text>
               </Flex>
             )}
-
-            {isLoading ? (
-              <Spinner />
-            ) : (
-              // suggestedUsers.map((user) => (
-              //   <SuggestedUser user={user} key={user.uid} />
-              // ))
-              '구현중입니다'
-            )}
+            {users?.map((user) => (
+              <SuggestedUser user={user} key={user.uid} />
+            ))}
           </VStack>
         </ModalBody>
       </ModalContent>
@@ -57,4 +44,4 @@ const UserModal = ({ mode = '', isOpen, onClose }) => {
   );
 };
 
-export default UserModal;
+export default FollowerModal;

--- a/src/components/Modals/FollowingModal.jsx
+++ b/src/components/Modals/FollowingModal.jsx
@@ -1,0 +1,47 @@
+import {
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalOverlay,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+import SuggestedUser from '../SuggestedUsers/SuggestedUser';
+
+const FollowingModal = ({ users, isOpen, onClose }) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered={true}
+      size={{ base: 'xl', md: '3xl' }}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalBody bg={'black'} pb={5}>
+          <VStack py={8} px={6} gap={4}>
+            {users?.length !== 0 && (
+              <Flex
+                justifyContent={'space-between'}
+                alignItems={'center'}
+                w={'full'}
+              >
+                <Text fontSize={12} fontWeight={'bold'} color={'gray.500'}>
+                  following user List
+                </Text>
+              </Flex>
+            )}
+            {users?.map((user) => (
+              <SuggestedUser user={user} key={user.uid} />
+            ))}
+          </VStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default FollowingModal;

--- a/src/components/Profile/ProfileHeader.jsx
+++ b/src/components/Profile/ProfileHeader.jsx
@@ -11,8 +11,11 @@ import { useUserProfileStore } from '../../store/userProfileStore';
 import { useAuthStore } from '../../store/authStore';
 import EditProfile from './EditProfile';
 import useFollowUser from '../../hooks/User/useFollowUser';
-import UserModal from '../Modals/UserModal';
-import { useState } from 'react';
+import FollowerModal from '../Modals/FollowerModal';
+import { useEffect, useState } from 'react';
+import useGetFollowers from '../../hooks/User/useGetFollowers';
+import useGetFollowing from '../../hooks/User/useGetFollowing';
+import FollowingModal from '../Modals/FollowingModal';
 
 export default function ProfileHeader() {
   const { userProfile } = useUserProfileStore();
@@ -20,19 +23,20 @@ export default function ProfileHeader() {
   const ownProfile = user && user.username === userProfile.username;
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [openFollowers, setOpenFollowers] = useState(false);
-  const [followMode, setFollowMode] = useState('follower');
+  const [openFollowings, setOpenFollowings] = useState(false);
   const { isUpdating, isFollowing, handleFollowUser } = useFollowUser(
     userProfile?.uid
   );
 
+  const { followUsers } = useGetFollowers();
+  const { followingUsers } = useGetFollowing();
+
   const handleShowFollowers = () => {
     setOpenFollowers(true);
-    setFollowMode('follower');
   };
 
   const handleShowFollowings = () => {
-    setOpenFollowers(true);
-    setFollowMode('following');
+    setOpenFollowings(true);
   };
 
   return (
@@ -103,7 +107,6 @@ export default function ProfileHeader() {
             fontSize={{ base: 'xs', md: 'sm' }}
             pointer={'hover'}
             onClick={handleShowFollowers}
-            p={0}
           >
             <Text as='span' fontWeight={'bold'} mr={1}>
               {userProfile.followers.length}
@@ -114,7 +117,6 @@ export default function ProfileHeader() {
             fontSize={{ base: 'xs', md: 'sm' }}
             pointer={'hover'}
             onClick={handleShowFollowings}
-            p={0}
           >
             <Text as='span' fontWeight={'bold'} mr={1}>
               {userProfile.following.length}
@@ -122,18 +124,18 @@ export default function ProfileHeader() {
             Following
           </Button>
         </Flex>
-        <Flex alignItems={'center'} gap={4}>
-          <Text fontSize={'sm'} fontWeight={'bold'}>
-            {userProfile.username}
-          </Text>
-        </Flex>
         <Text fontSize={'sm'}>{userProfile.bio}</Text>
       </VStack>
       {isOpen && <EditProfile isOpen={isOpen} onClose={onClose} />}
-      <UserModal
-        mode={followMode}
+      <FollowerModal
+        users={followUsers}
         isOpen={openFollowers}
         onClose={() => setOpenFollowers(false)}
+      />
+      <FollowingModal
+        users={followingUsers}
+        isOpen={openFollowings}
+        onClose={() => setOpenFollowings(false)}
       />
     </Flex>
   );

--- a/src/hooks/User/useGetFollowing.js
+++ b/src/hooks/User/useGetFollowing.js
@@ -4,36 +4,36 @@ import useShowToast from '../useShowToast';
 import { collection, getDocs, orderBy, query, where } from 'firebase/firestore';
 import { firestore } from '../../firebase/firebase';
 
-const useGetFollowers = () => {
+const useGetFollowing = () => {
   const [isLoading, setIsLoading] = useState(true);
-  const [followUsers, setFollowUsers] = useState([]);
+  const [followingUsers, setFollowingUsers] = useState([]);
   const { user } = useAuthStore();
   const showToast = useShowToast();
 
   useEffect(() => {
-    const getFollow = async () => {
+    const getFollowings = async () => {
       setIsLoading(true);
       try {
         const usersRef = collection(firestore, 'users');
         const q = query(
           usersRef,
-          where('uid', 'in', user.followers),
+          where('uid', 'in', user.following),
           orderBy('uid')
         );
 
         const querySnapshot = await getDocs(q);
-        const followers = [];
+        const users = [];
 
         querySnapshot.forEach((doc) => {
-          followers.push({ ...doc.data(), id: doc.id });
+          users.push({ ...doc.data(), id: doc.id });
         });
 
-        setFollowUsers(followers);
+        setFollowingUsers(users);
       } catch (error) {
         console.error(error);
         showToast(
           'Error',
-          'follower 목록 조회 실패, 잠시후 시도해주세요',
+          'following목록 조회 실패, 잠시후 시도해주세요',
           'error'
         );
       } finally {
@@ -41,10 +41,10 @@ const useGetFollowers = () => {
       }
     };
 
-    if (user) getFollow();
+    if (user) getFollowings();
   }, [user, showToast]);
 
-  return { isLoading, followUsers };
+  return { isLoading, followingUsers };
 };
 
-export default useGetFollowers;
+export default useGetFollowing;


### PR DESCRIPTION
### 팔로워, 팔로우 클릭시 유저목록 보여주기 업데이트
- 고칠점이 많음
- follow에도 useMutation적용하려 했으나 follower, following 등 정보는 다 user에서 가져오고 있었고 로그인 시 authStore의 login함수 통해 setUser로 저장함.
- 뷰 업데이트 위해서는 또 follow추가또는 취소 또는 조회 시 적절한 뷰 업데이트 위해서는 auth로직 전체를 react-qeury로 데이터 캐싱 필요
- 너무 여기저기서 authStore와 profileStore의 user정보를 쓰고 있어 당장 바꾸기 어려움
- 추후 데이터 관리 수정 시 user관련된 정보 queryKey로 관리하도록 변경 필요
- 현재 뷰 업데이트를 위한 로직이 store에 불필요하게 많고 useMutation훅들로 user를 props로 넘기는 경우 많음
- 팔로워, 팔로잉 목록에서 unfollow/follow시 프로필헤더에 뷰 업데이트 안됨